### PR TITLE
Split the ApiCacheBust middleware into 3 separate middlewares

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -62,6 +62,7 @@ class ConfigProvider
                 'ExpressivePrismic\Middleware\WebhookMiddlewarePipe' => Middleware\Factory\WebhookMiddlewarePipeFactory::class,
 
                 // Processes Webhooks from Prismic.io and busts the cache
+                Middleware\ValidatePrismicWebhook::class => Middleware\Factory\ValidatePrismicWebhookFactory::class,
                 Middleware\ApiCacheBust::class => Middleware\Factory\ApiCacheBustFactory::class,
 
                 // Processes a preview token and redirects to the page being previewed
@@ -90,6 +91,7 @@ class ConfigProvider
 
                 // Turns 404 errors into exceptions
                 Middleware\NormalizeNotFound::class    => Middleware\NormalizeNotFound::class,
+                Middleware\JsonSuccess::class    => Middleware\JsonSuccess::class,
             ],
             'aliases' => [
                 /**

--- a/src/Middleware/ApiCacheBust.php
+++ b/src/Middleware/ApiCacheBust.php
@@ -4,72 +4,28 @@ namespace ExpressivePrismic\Middleware;
 
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Zend\Diactoros\Response\JsonResponse;
-use Prismic;
+use Prismic\Cache\CacheInterface;
 
 class ApiCacheBust implements MiddlewareInterface
 {
     /**
-     * @var Prismic\Api
+     * @var CacheInterface
      */
-    private $api;
+    private $cache;
 
-    /**
-     * @var string
-     */
-    private $expectedSecret;
-
-    public function __construct(Prismic\Api $api, string $expectedSecret)
+    public function __construct(CacheInterface $cache)
     {
-        $this->api = $api;
-        $this->expectedSecret = $expectedSecret;
+        $this->cache = $cache;
     }
 
     public function process(Request $request, DelegateInterface $delegate)
     {
-        $body = (string) $request->getBody();
-
-        if (empty($body)) {
-            return $this->jsonError('Bad Request', 400);
+        $data = $request->getAttribute(ValidatePrismicWebhook::class);
+        if ($data && isset($data['type']) && $data['type'] === 'api-update') {
+            $this->cache->clear();
         }
-
-        $json = json_decode($body, true, 10);
-
-        if (!$json) {
-            return $this->jsonError('Invalid payload', 400);
-        }
-
-
-        if (!isset($json['secret']) || $json['secret'] !== $this->expectedSecret) {
-            return $this->jsonError('Invalid payload', 400);
-        }
-
-        if (isset($json['type']) && $json['type'] === 'api-update') {
-            if ($cache = $this->api->getCache()) {
-                $cache->clear();
-            }
-        }
-
-        $data = [
-            'error' => false,
-            'message' => 'Payload Received',
-        ];
-
-        return new JsonResponse($data, 200);
+        return $delegate->process($request);
     }
 
-    /**
-     * Return a JSON Response in error conditions with the given message and status code
-     */
-    private function jsonError(string $message, int $code) : JsonResponse
-    {
-        $data = [
-            'error' => true,
-            'message' => $message,
-        ];
-
-        return new JsonResponse($data, $code);
-    }
 }

--- a/src/Middleware/Factory/ApiCacheBustFactory.php
+++ b/src/Middleware/Factory/ApiCacheBustFactory.php
@@ -4,7 +4,8 @@ declare(strict_types = 1);
 namespace ExpressivePrismic\Middleware\Factory;
 
 use Psr\Container\ContainerInterface;
-use Prismic;
+use Prismic\Api;
+use Prismic\Cache\CacheInterface;
 use ExpressivePrismic\Middleware\ApiCacheBust;
 
 class ApiCacheBustFactory
@@ -12,11 +13,8 @@ class ApiCacheBustFactory
 
     public function __invoke(ContainerInterface $container) : ApiCacheBust
     {
-        $api = $container->get(Prismic\Api::class);
-        $config = $container->get('config');
-        $secret = isset($config['prismic']['webhook_secret']) ? $config['prismic']['webhook_secret'] : null;
-
-        return new ApiCacheBust($api, $secret);
+        $api = $container->get(Api::class);
+        return new ApiCacheBust($api->getCache());
     }
 
 }

--- a/src/Middleware/Factory/ValidatePrismicWebhookFactory.php
+++ b/src/Middleware/Factory/ValidatePrismicWebhookFactory.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types = 1);
+
+namespace ExpressivePrismic\Middleware\Factory;
+
+use Psr\Container\ContainerInterface;
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
+
+class ValidatePrismicWebhookFactory
+{
+
+    public function __invoke(ContainerInterface $container) : ValidatePrismicWebhook
+    {
+        $config = $container->get('config');
+        $secret = isset($config['prismic']['webhook_secret']) ? $config['prismic']['webhook_secret'] : null;
+        return new ValidatePrismicWebhook($secret);
+    }
+
+}

--- a/src/Middleware/Factory/WebhookMiddlewarePipeFactory.php
+++ b/src/Middleware/Factory/WebhookMiddlewarePipeFactory.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace ExpressivePrismic\Middleware\Factory;
 
-use ExpressivePrismic\Middleware\ApiCacheBust;
 use Psr\Container\ContainerInterface;
 use Zend\Stratigility\MiddlewarePipe;
+
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
+use ExpressivePrismic\Middleware\ApiCacheBust;
+use ExpressivePrismic\Middleware\JsonSuccess;
 
 class WebhookMiddlewarePipeFactory
 {
@@ -13,7 +16,9 @@ class WebhookMiddlewarePipeFactory
     public function __invoke(ContainerInterface $container) : MiddlewarePipe
     {
         $pipeline = new MiddlewarePipe();
+        $pipeline->pipe($container->get(ValidatePrismicWebhook::class));
         $pipeline->pipe($container->get(ApiCacheBust::class));
+        $pipeline->pipe($container->get(JsonSuccess::class));
         return $pipeline;
     }
 

--- a/src/Middleware/JsonSuccess.php
+++ b/src/Middleware/JsonSuccess.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+namespace ExpressivePrismic\Middleware;
+
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response\JsonResponse;
+
+class JsonSuccess implements MiddlewareInterface
+{
+
+    public function process(Request $request, DelegateInterface $delegate)
+    {
+        $data = [
+            'success' => true,
+            'message' => 'Payload Received',
+        ];
+
+        return new JsonResponse($data, 200);
+
+    }
+
+}

--- a/src/Middleware/ValidatePrismicWebhook.php
+++ b/src/Middleware/ValidatePrismicWebhook.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types = 1);
+namespace ExpressivePrismic\Middleware;
+
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response\JsonResponse;
+
+/**
+ * Middleware that returns an error response if the webhook post
+ * is not valid, otherwise delegates to the next middleware in the queue after
+ * setting the decoded, posted payload as a request attribute
+ */
+
+class ValidatePrismicWebhook implements MiddlewareInterface
+{
+
+    /**
+     * @var string
+     */
+    private $expectedSecret;
+
+    public function __construct(string $expectedSecret)
+    {
+        $this->expectedSecret = $expectedSecret;
+    }
+
+    public function process(Request $request, DelegateInterface $delegate)
+    {
+        $body = (string) $request->getBody();
+
+        if (empty($body)) {
+            return $this->jsonError('Bad Request', 400);
+        }
+
+        $json = json_decode($body, true, 10);
+
+        if (!$json) {
+            return $this->jsonError('Invalid payload', 400);
+        }
+
+
+        if (!isset($json['secret']) || $json['secret'] !== $this->expectedSecret) {
+            return $this->jsonError('Invalid payload', 400);
+        }
+
+        $request = $request->withAttribute(__CLASS__, $json);
+
+        return $delegate->process($request);
+    }
+
+    /**
+     * Return a JSON Response in error conditions with the given message and status code
+     */
+    private function jsonError(string $message, int $code) : JsonResponse
+    {
+        $data = [
+            'error' => true,
+            'message' => $message,
+        ];
+
+        return new JsonResponse($data, $code);
+    }
+}

--- a/test/ExpressivePrismic/Middleware/ApiCacheBustTest.php
+++ b/test/ExpressivePrismic/Middleware/ApiCacheBustTest.php
@@ -13,123 +13,79 @@ use ExpressivePrismic\Middleware\ApiCacheBust;
 // Deps
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Zend\Diactoros\Response\JsonResponse;
-use Prismic;
+use Prismic\Cache\CacheInterface;
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
 
 class ApiCacheBustTest extends TestCase
 {
 
     private $cache;
-    private $api;
     private $delegate;
     private $request;
 
     public function setUp()
     {
-        $this->cache    = $this->prophesize(Prismic\Cache\CacheInterface::class);
-        $this->api      = $this->prophesize(Prismic\Api::class);
+        $this->cache    = $this->prophesize(CacheInterface::class);
         $this->delegate = $this->prophesize(DelegateInterface::class);
         $this->request  = $this->prophesize(Request::class);
     }
 
-    public function getMiddleware(string $expectedSecret = 'foo')
+    public function getMiddleware()
     {
         return new ApiCacheBust(
-            $this->api->reveal(),
-            $expectedSecret
+            $this->cache->reveal()
         );
     }
 
-    public function testEmptyRequestBodyIsError()
-    {
-        $this->request->getBody()->willReturn(null);
 
-        $middleware = $this->getMiddleware();
-
-        $response = $middleware->process(
-            $this->request->reveal(),
-            $this->delegate->reveal()
-        );
-
-        $this->assertJsonResponseIsError($response, 400);
-    }
-
-    private function assertJsonResponseIsError($response, $expectedCode = 400)
-    {
-        $this->assertSame($expectedCode, $response->getStatusCode());
-        $json = json_decode((string)$response->getBody(), true);
-        $this->assertTrue($json['error']);
-        $this->assertInternalType('string', $json['message']);
-    }
-
-    private function assertJsonResponseIsSuccess($response)
-    {
-        $this->assertSame(200, $response->getStatusCode());
-        $json = json_decode((string)$response->getBody(), true);
-        $this->assertFalse($json['error']);
-        $this->assertInternalType('string', $json['message']);
-    }
-
-    public function testInvalidJsonIsError()
-    {
-        $this->request->getBody()->willReturn('foo');
-        $middleware = $this->getMiddleware();
-        $response = $middleware->process(
-            $this->request->reveal(),
-            $this->delegate->reveal()
-        );
-
-        $this->assertJsonResponseIsError($response, 400);
-    }
-
-    public function testMissingSecretIsError()
-    {
-        $this->request->getBody()->willReturn('{"json" : "foo"}');
-        $middleware = $this->getMiddleware();
-        $response = $middleware->process(
-            $this->request->reveal(),
-            $this->delegate->reveal()
-        );
-        $this->assertJsonResponseIsError($response, 400);
-    }
-
-    public function testIncorrectSecretIsError()
-    {
-        $this->request->getBody()->willReturn('{"secret" : "wrong"}');
-        $middleware = $this->getMiddleware();
-        $response = $middleware->process(
-            $this->request->reveal(),
-            $this->delegate->reveal()
-        );
-        $this->assertJsonResponseIsError($response, 400);
-    }
-
-    public function testCorrectSecretIsSuccess()
-    {
-        $this->request->getBody()->willReturn('{"secret" : "wrong"}');
-        $middleware = $this->getMiddleware('wrong');
-        $response = $middleware->process(
-            $this->request->reveal(),
-            $this->delegate->reveal()
-        );
-        $this->assertJsonResponseIsSuccess($response);
-    }
 
     public function testCacheIsCleanedWithApiUpdate()
     {
         $this->cache->clear()->shouldBeCalled();
-        $this->api->getCache()->willReturn($this->cache->reveal());
 
-        $this->request->getBody()->willReturn('{"secret" : "wrong", "type":"api-update"}');
-        $middleware = $this->getMiddleware('wrong');
-        $response = $middleware->process(
+        $this->request->getAttribute(ValidatePrismicWebhook::class)->willReturn([
+            'type' => 'api-update',
+        ]);
+
+        $this->delegate->process($this->request->reveal())->shouldBeCalled();
+
+        $middleware = $this->getMiddleware();
+        $middleware->process(
             $this->request->reveal(),
             $this->delegate->reveal()
         );
-        $this->assertJsonResponseIsSuccess($response);
 
+    }
+
+    public function testCacheIsNotCleanedWithoutApiUpdate()
+    {
+        $this->cache->clear()->shouldNotBeCalled();
+
+        $this->request->getAttribute(ValidatePrismicWebhook::class)->willReturn([
+            'type' => 'other-update',
+        ]);
+
+        $this->delegate->process($this->request->reveal())->shouldBeCalled();
+
+        $middleware = $this->getMiddleware();
+        $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+    }
+
+    public function testNoopWithoutValidationAttribute()
+    {
+        $this->cache->clear()->shouldNotBeCalled();
+        $this->request->getAttribute(ValidatePrismicWebhook::class)->willReturn(null);
+        $this->delegate->process($this->request->reveal())->shouldBeCalled();
+
+        $middleware = $this->getMiddleware();
+        $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
     }
 
 

--- a/test/ExpressivePrismic/Middleware/Factory/ApiCacheBustFactoryTest.php
+++ b/test/ExpressivePrismic/Middleware/Factory/ApiCacheBustFactoryTest.php
@@ -12,8 +12,9 @@ use ExpressivePrismic\Middleware\Factory\ApiCacheBustFactory;
 
 // Deps
 use Psr\Container\ContainerInterface;
-use Prismic;
+use Prismic\Api;
 use ExpressivePrismic\Middleware\ApiCacheBust;
+use Prismic\Cache\CacheInterface;
 
 class ApiCacheBustFactoryTest extends TestCase
 {
@@ -27,14 +28,13 @@ class ApiCacheBustFactoryTest extends TestCase
 
     public function testFactory()
     {
-        $this->container->get(Prismic\Api::class)->willReturn(
-            $this->prophesize(Prismic\Api::class)->reveal()
+        $api = $this->prophesize(Api::class);
+        $cache = $this->prophesize(CacheInterface::class)->reveal();
+        $api->getCache()->willReturn($cache);
+
+        $this->container->get(Api::class)->willReturn(
+            $api->reveal()
         );
-        $this->container->get('config')->willReturn([
-            'prismic' => [
-                'webhook_secret' => 'foo',
-            ],
-        ]);
 
         $factory = new ApiCacheBustFactory;
 

--- a/test/ExpressivePrismic/Middleware/Factory/ValidatePrismicWebhookFactoryTest.php
+++ b/test/ExpressivePrismic/Middleware/Factory/ValidatePrismicWebhookFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace ExpressivePrismicTest\Middleware\Factory;
+
+// Infra
+use ExpressivePrismicTest\TestCase;
+use Prophecy\Argument;
+
+// SUT
+use ExpressivePrismic\Middleware\Factory\ValidatePrismicWebhookFactory;
+
+// Deps
+use Psr\Container\ContainerInterface;
+use Prismic\Api;
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
+use Prismic\Cache\CacheInterface;
+
+class ValidatePrismicWebhookFactoryTest extends TestCase
+{
+
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testFactory()
+    {
+        $this->container->get('config')->willReturn([
+            'prismic' => [
+                'webhook_secret' => 'foo'
+            ]
+        ]);
+
+        $factory = new ValidatePrismicWebhookFactory;
+
+        $middleware = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(ValidatePrismicWebhook::class, $middleware);
+    }
+}

--- a/test/ExpressivePrismic/Middleware/Factory/WebhookMiddlewarePipeFactoryTest.php
+++ b/test/ExpressivePrismic/Middleware/Factory/WebhookMiddlewarePipeFactoryTest.php
@@ -13,7 +13,9 @@ use ExpressivePrismic\Middleware\Factory\WebhookMiddlewarePipeFactory;
 // Deps
 use Psr\Container\ContainerInterface;
 use Zend\Stratigility\MiddlewarePipe;
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
 use ExpressivePrismic\Middleware\ApiCacheBust;
+use ExpressivePrismic\Middleware\JsonSuccess;
 
 class WebhookMiddlewarePipeFactoryTest extends TestCase
 {
@@ -29,6 +31,12 @@ class WebhookMiddlewarePipeFactoryTest extends TestCase
     {
         $this->container->get(ApiCacheBust::class)->willReturn(
             $this->prophesize(ApiCacheBust::class)->reveal()
+        );
+        $this->container->get(ValidatePrismicWebhook::class)->willReturn(
+            $this->prophesize(ValidatePrismicWebhook::class)->reveal()
+        );
+        $this->container->get(JsonSuccess::class)->willReturn(
+            $this->prophesize(JsonSuccess::class)->reveal()
         );
 
         $factory = new WebhookMiddlewarePipeFactory;

--- a/test/ExpressivePrismic/Middleware/JsonSuccessTest.php
+++ b/test/ExpressivePrismic/Middleware/JsonSuccessTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace ExpressivePrismicTest\Middleware;
+
+// Infra
+use ExpressivePrismicTest\TestCase;
+use Prophecy\Argument;
+
+// SUT
+use ExpressivePrismic\Middleware\JsonSuccess;
+
+// Deps
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Diactoros\Response\JsonResponse;
+
+class JsonSuccessTest extends TestCase
+{
+
+    public function testJsonReturned()
+    {
+        $request = $this->prophesize(Request::class)->reveal();
+        $delegate = $this->prophesize(DelegateInterface::class);
+        $delegate->process()->shouldNotBeCalled();
+
+        $middleware = new JsonSuccess;
+
+        $response = $middleware->process($request, $delegate->reveal());
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+
+    }
+
+}

--- a/test/ExpressivePrismic/Middleware/ValidatePrismicWebhookTest.php
+++ b/test/ExpressivePrismic/Middleware/ValidatePrismicWebhookTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace ExpressivePrismicTest\Middleware;
+
+// Infra
+use ExpressivePrismicTest\TestCase;
+use Prophecy\Argument;
+
+// SUT
+use ExpressivePrismic\Middleware\ValidatePrismicWebhook;
+
+// Deps
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ValidatePrismicWebhookTest extends TestCase
+{
+
+    private $delegate;
+    private $request;
+
+    public function setUp()
+    {
+        $this->delegate = $this->prophesize(DelegateInterface::class);
+        $this->request  = $this->prophesize(Request::class);
+    }
+
+    public function getMiddleware()
+    {
+        return new ValidatePrismicWebhook(
+            'big-secret'
+        );
+    }
+
+    public function testEmptyRequestBodyIsError()
+    {
+        $this->request->getBody()->willReturn(null);
+
+        $middleware = $this->getMiddleware();
+
+        $response = $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+
+        $this->assertJsonResponseIsError($response, 400);
+    }
+
+    private function assertJsonResponseIsError($response, $expectedCode = 400)
+    {
+        $this->assertSame($expectedCode, $response->getStatusCode());
+        $json = json_decode((string)$response->getBody(), true);
+        $this->assertTrue($json['error']);
+        $this->assertInternalType('string', $json['message']);
+    }
+
+    public function testInvalidJsonIsError()
+    {
+        $this->request->getBody()->willReturn('foo');
+        $middleware = $this->getMiddleware();
+        $response = $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+
+        $this->assertJsonResponseIsError($response, 400);
+    }
+
+    public function testMissingSecretIsError()
+    {
+        $this->request->getBody()->willReturn('{"json" : "foo"}');
+        $middleware = $this->getMiddleware();
+        $response = $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+        $this->assertJsonResponseIsError($response, 400);
+    }
+
+    public function testIncorrectSecretIsError()
+    {
+        $this->request->getBody()->willReturn('{"secret" : "wrong"}');
+        $middleware = $this->getMiddleware();
+        $response = $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+        $this->assertJsonResponseIsError($response, 400);
+    }
+
+    public function testCorrectSecretIsSuccess()
+    {
+        $this->request->getBody()->willReturn('{"secret" : "big-secret"}');
+        $this->request->withAttribute(ValidatePrismicWebhook::class,['secret'=>'big-secret'])->willReturn($this->request->reveal());
+        $this->delegate->process($this->request->reveal())->shouldBeCalled();
+        $middleware = $this->getMiddleware();
+        $response = $middleware->process(
+            $this->request->reveal(),
+            $this->delegate->reveal()
+        );
+    }
+}
+


### PR DESCRIPTION
Instead of having one middleware that validates the web hook, determines if it's an update and returns a response, split the pipeline into 3 where first the request is validated as a web hook post, then if valid, the cache is busted depending on the inspection of the payload, finally another middleware is responsible for returning a request.