### PR TITLE
Expire experiment cookies when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 4.2.0 - TBD
+
+### Added
+
+- [#9](https://github.com/netglue/Expressive-Prismic/pull/9) Expires experiment cookies if a cookie is present in the 
+request and the Api reports that no experiments are running. This action occurs in the `ExperimentInitiator` middleware. 
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.1.0 - 2018-11-13
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "dflydev/fig-cookies": "^2.0",
+        "dflydev/fig-cookies": "^1.0",
         "netglue/prismic-php-kit": "^4.0",
         "zendframework/zend-diactoros": "^1.7",
         "zendframework/zend-expressive": "^3.0.1",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "dflydev/fig-cookies": "^2.0",
         "netglue/prismic-php-kit": "^4.0",
         "zendframework/zend-diactoros": "^1.7",
         "zendframework/zend-expressive": "^3.0.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "dflydev/fig-cookies": "^1.0",
+        "dflydev/fig-cookies": "^1.0|^2.0",
         "netglue/prismic-php-kit": "^4.0",
         "zendframework/zend-diactoros": "^1.7",
         "zendframework/zend-expressive": "^3.0.1",


### PR DESCRIPTION
Update the Experiment Initiator middleware to expire the experiment cookie if present and no experiment is running