### PR TITLE
Update documentation about the webhook secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ request and the Api reports that no experiments are running. This action occurs 
 
 ### Changed
 
-- Nothing.
+- [#10](https://github.com/netglue/Expressive-Prismic/pull/10) Documents the requirement for a (string) shared secret for
+authenticating webhooks. Also adds `ext-json` to composer as a previously hidden dependency _(FWIW)_
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ route like this _(If you are using FastRoute)_:
 ## Cache Busting Webhook
 
 You will see in `Factory\PipelineAndRoutesDelegator` that two routes are wired in by default, one of these is the
-webhook to bust the cache. In order to use it, you will need to provide the shared secret that Prismic.io sends in it's
+webhook to bust the cache. In order to use it, you **will need** to provide the shared secret that Prismic.io sends in it's
 webhook payload to a local configuration file or Config Provider like this:
 
 ```php
@@ -105,6 +105,10 @@ webhook payload to a local configuration file or Config Provider like this:
         ],
     ];
 ```
+
+> By default the secret is `null`, so if you don't set it the Validation middleware will cause a `TypeError` due to the
+> secret string being a constructor dependency. If it's really important that you don't use a shared secret, you'll have
+> to override `ValidatePrismicWebhook` with your own middleware or configure your own pipeline and webhook handlers.
 
 The Url of the webhook will be `/prismicio-cache-webhook` - given a valid Json payload containing a matching shared
 secret, the pre-configured middleware will empty the cache attached to the Prismic API instance.

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "ext-json": "*",
         "dflydev/fig-cookies": "^1.0|^2.0",
         "netglue/prismic-php-kit": "^4.0",
         "zendframework/zend-diactoros": "^1.7",

--- a/src/Middleware/ValidatePrismicWebhook.php
+++ b/src/Middleware/ValidatePrismicWebhook.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 namespace ExpressivePrismic\Middleware;
 
 use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Zend\Diactoros\Response\JsonResponse;
@@ -27,7 +27,7 @@ class ValidatePrismicWebhook implements MiddlewareInterface
         $this->expectedSecret = $expectedSecret;
     }
 
-    public function process(Request $request, DelegateInterface $delegate) : Response
+    public function process(Request $request, RequestHandlerInterface $handler) : Response
     {
         $body = (string) $request->getBody();
 
@@ -48,7 +48,7 @@ class ValidatePrismicWebhook implements MiddlewareInterface
 
         $request = $request->withAttribute(__CLASS__, $json);
 
-        return $delegate->handle($request);
+        return $handler->handle($request);
     }
 
     /**


### PR DESCRIPTION
Resolves #5 in that no code changes are made, but makes it clear in the readme that a secret is required from the end user and explains the error. Also adds `ext-json` to composer deps as a previously missing dependency.