### PR TITLE
Preview cookie is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ request and the Api reports that no experiments are running. This action occurs 
 
 - [#10](https://github.com/netglue/Expressive-Prismic/pull/10) Documents the requirement for a (string) shared secret for
 authenticating webhooks. Also adds `ext-json` to composer as a previously hidden dependency _(FWIW)_
+- [#11](https://github.com/netglue/Expressive-Prismic/pull/11) Changed the PreviewInitiator middleware so that it no
+longer sets a cookie. The JS toolbar now sets this for you and if you want previews, you need to have it installed
+anyway. This double setting of the preview cookie has been causing problems when both are successfully set. The
+middleware also checks for an `ExpiredPreviewTokenException` and presents a more friendly error message for previewers.
+This exception only became available in the PHP Kit version 4.2, just released, so composer.json is updated to
+require it.
+- `ExceptionInterface` now correctly extends `Throwable`
 
 ### Deprecated
 
@@ -20,7 +27,7 @@ authenticating webhooks. Also adds `ext-json` to composer as a previously hidden
 
 ### Removed
 
-- Nothing.
+- Removed pointless test bootstrap and cleaned up phpunit config.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ add the URL in the settings on your Prismic repository and clicks on the preview
 the site in preview mode. You can see how this is configured in `Factory\PipelineAndRoutesDelegator` - the URL is
 `/prismic-preview`
 
+> In 4.2.0, the middleware responsible for initiating a preview session was altered to catch an exception that is
+> thrown when the preview token has expired and subsequently return a simple html response with a descriptive error.
+> Previously, in this situation, an uncaught exception would have occurred.  
+
 ## View Helpers
 
 ### URL Helper `$this->prismicUrl()`

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "dflydev/fig-cookies": "^1.0|^2.0",
-        "netglue/prismic-php-kit": "^4.0",
+        "netglue/prismic-php-kit": "^4.2",
         "zendframework/zend-diactoros": "^1.7",
         "zendframework/zend-expressive": "^3.0.1",
         "zendframework/zend-expressive-helpers": "^5.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-	bootstrap="./test/bootstrap.php"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	verbose="true"
-	stopOnFailure="false"
-	processIsolation="false"
-	backupGlobals="false"
-	>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true">
     <testsuites>
         <testsuite name="Zend Expressive Prismic Module Test Suite">
             <directory suffix="Test.php">./test/ExpressivePrismic</directory>

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -2,11 +2,8 @@
 declare(strict_types=1);
 namespace ExpressivePrismic\Exception;
 
-/**
- * Interface ExceptionInterface
- *
- * @package ExpressivePrismic\Exception
- */
-interface ExceptionInterface
+use Throwable;
+
+interface ExceptionInterface extends Throwable
 {
 }

--- a/src/Middleware/PreviewInitiator.php
+++ b/src/Middleware/PreviewInitiator.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace ExpressivePrismic\Middleware;
 
+use ExpressivePrismic\Exception\RuntimeException;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as DelegateInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Prismic;
-use Zend\Http\Header\SetCookie;
+use Prismic\Exception as PrismicException;
+use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\RedirectResponse;
 
 class PreviewInitiator implements MiddlewareInterface
@@ -35,33 +37,39 @@ class PreviewInitiator implements MiddlewareInterface
         $token = urldecode($query['token']);
 
         /**
-         * If you don't set the cookie, the Prismic Preview Icon will not show up
-         * at the bottom of the page
-         */
-
-        /**
-         * @todo Ideally cookie expiry would be configurable
-         */
-        $expires = time() + (29 * 60);
-
-        /** @var \Psr\Http\Message\UriInterface */
-        $uri = $request->getUri();
-
-        $cookie = new SetCookie(
-            Prismic\Api::PREVIEW_COOKIE,
-            $token,
-            $expires,
-            null, // $path - Can't see a use case for limiting to specific path right now
-            $uri->getHost(), // $domain
-            ($uri->getScheme() === 'https'), // $secure - true if current scheme is
-            false // $httpOnly - Nope, JS needs this cookie
-        );
-
-        /**
          * Figure out URL and redirect
          */
-        $url = $this->api->previewSession($token, '/');
+        try {
+            $url = $this->api->previewSession($token, '/');
+            return new RedirectResponse($url, 302);
+        } catch (PrismicException\ExceptionInterface $exception) {
+            /**
+             * If possible return a more friendly error message for the relatively common occurrence that a
+             * preview token has expired
+             */
+            if ($exception instanceof PrismicException\ExpiredPreviewTokenException) {
+                return $this->generatePreviewExpiredError();
+            }
+            throw new RuntimeException(
+                'An unknown error has occurred',
+                500,
+                $exception
+            );
+        }
+    }
 
-        return new RedirectResponse($url, 302, [$cookie->getFieldName() => $cookie->getFieldValue()]);
+    private function generatePreviewExpiredError() : Response
+    {
+        $responseBody = <<<EOF
+<html>
+<head><title>Error: Preview Expired</title></head>
+<body>
+<h1>Preview Token Expired</h1>
+<p>This error occurs when you re-use an out of date link to preview content.</p>
+<p>Simply <a href="/">navigate away</a> from this error, or start a fresh preview session from within the CMS.</p>
+</body>
+</html>
+EOF;
+        return new HtmlResponse($responseBody, 410);
     }
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
The JS toolbar now sets this for you and if you want previews, you need
to have it installed anyway. This double setting of the preview cookie
has been causing problems when both are successfully set.
The middleware also checks for an ExpiredPreviewTokenException and
presents a more friendly error message for previewers. This exception
only became available in the PHP Kit version 4.2, just released, so
composer.json is updated to require it