### PR TITLE
Fix Incorrect Document Returned when Language Parameter is Present

### DIFF
--- a/src/Middleware/DocumentResolver.php
+++ b/src/Middleware/DocumentResolver.php
@@ -121,6 +121,9 @@ class DocumentResolver implements MiddlewareInterface
         if (! $type || ! $uid) {
             return null;
         }
-        return $this->api->getByUid($type, $uid);
+        $search = $this->routeParams->getLang();
+        $lang = isset($params[$search]) && ! empty($params[$search]) ? (string) $params[$search] : null;
+        $options = $lang ? ['lang' => $lang] : [];
+        return $this->api->getByUid($type, $uid, $options);
     }
 }


### PR DESCRIPTION
Because 2 translations of the same document can have identical UIDs, the language matched in routing parameters should be sent when locating a document with UID in order to retrieve the correct doc