### PR TITLE
Nullable Web Hook secret & Configurable URLs

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -190,6 +190,10 @@ class ConfigProvider
 
             // Webhook Shared Secret
             'webhook_secret' => null,
+            // URL where webhooks will get POSTed
+            'webhook_url' => '/prismicio-cache-webhook',
+            // URL for Previews
+            'preview_url' => '/prismic-preview',
 
             /**
              * Error Handler configuration for content managed

--- a/src/Container/PipelineAndRoutesDelegator.php
+++ b/src/Container/PipelineAndRoutesDelegator.php
@@ -9,27 +9,28 @@ use ExpressivePrismic\Middleware;
 
 class PipelineAndRoutesDelegator
 {
-    /**
-     * @param ContainerInterface $container
-     * @param string $serviceName Name of the service being created.
-     * @param callable $callback Creates and returns the service.
-     * @return Application
-     */
     public function __invoke(ContainerInterface $container, $serviceName, callable $callback) : Application
     {
-        /** @var Application */
+        /** @var Application $app */
         $app = $callback();
+
+        $config = $container->get('config')['prismic'];
 
         /**
          * Preview Initiator
          */
-        $app->route('/prismic-preview', [Middleware\PreviewInitiator::class], ['GET'], 'prismic-preview');
+        $app->route(
+            $config['preview_url'],
+            [Middleware\PreviewInitiator::class],
+            ['GET'],
+            'prismic-preview'
+        );
 
         /**
          * Webhook Cache Bust
          */
         $app->route(
-            '/prismicio-cache-webhook',
+            $config['webhook_url'],
             [Middleware\WebhookPipe::class],
             ['POST'],
             'prismic-webhook-cache-bust'

--- a/src/Middleware/ValidatePrismicWebhook.php
+++ b/src/Middleware/ValidatePrismicWebhook.php
@@ -18,11 +18,11 @@ class ValidatePrismicWebhook implements MiddlewareInterface
 {
 
     /**
-     * @var string
+     * @var string|null
      */
     private $expectedSecret;
 
-    public function __construct(string $expectedSecret)
+    public function __construct(?string $expectedSecret = null)
     {
         $this->expectedSecret = $expectedSecret;
     }
@@ -41,9 +41,10 @@ class ValidatePrismicWebhook implements MiddlewareInterface
             return $this->jsonError('Invalid payload', 400);
         }
 
-
-        if (! isset($json['secret']) || $json['secret'] !== $this->expectedSecret) {
-            return $this->jsonError('Invalid payload', 400);
+        if ($this->expectedSecret) {
+            if (! isset($json['secret']) || $json['secret'] !== $this->expectedSecret) {
+                return $this->jsonError('Invalid payload', 400);
+            }
         }
 
         $request = $request->withAttribute(__CLASS__, $json);

--- a/test/ExpressivePrismic/Container/PipelineAndRoutesDelegatorTest.php
+++ b/test/ExpressivePrismic/Container/PipelineAndRoutesDelegatorTest.php
@@ -6,11 +6,13 @@ namespace ExpressivePrismicTest\Container;
 use ExpressivePrismic\Container\PipelineAndRoutesDelegator;
 use ExpressivePrismicTest\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Application;
 
 class PipelineAndRoutesDelegatorTest extends TestCase
 {
+    /** @var ContainerInterface&ObjectProphecy */
     private $container;
 
     public function setUp() : void
@@ -22,15 +24,28 @@ class PipelineAndRoutesDelegatorTest extends TestCase
     {
         $app = $this->prophesize(Application::class);
         $app->route(
-            Argument::type('string'),
+            '/webhook',
             Argument::type('array'),
             Argument::type('array'),
             Argument::type('string')
-        )->shouldBeCalledTimes(2);
+        )->shouldBeCalled();
+        $app->route(
+            '/preview',
+            Argument::type('array'),
+            Argument::type('array'),
+            Argument::type('string')
+        )->shouldBeCalled();
 
         $app = $app->reveal();
 
         $factory = new PipelineAndRoutesDelegator;
+
+        $this->container->get('config')->shouldBeCalled()->willReturn([
+            'prismic' => [
+                'webhook_url' => '/webhook',
+                'preview_url' => '/preview',
+            ],
+        ]);
 
         $return = $factory(
             $this->container->reveal(),


### PR DESCRIPTION
You can no longer set a secret in Prismic.io when configuring a webhook, so this pull allows a nullable secret.
Having no shared secret makes it important to be able to configure a random url for busting the cache, and it makes sense to make the preview url configurable too whilst we're at it.